### PR TITLE
Fix bug with sending messages

### DIFF
--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -82,7 +82,7 @@ function ChatWindow() {
         setDatesNMessagesArr(splitedByDate);
       });
     }
-  }, [activeChatID]);
+  }, [activeChatID, currentUser]);
 
   const messageContainerRef = useRef<HTMLDivElement>(null);
   const messageContainer = messageContainerRef.current;


### PR DESCRIPTION
## Что нового:
- пофикшен баг: _Если отправить в только что созданный чат сообщение, потом перезайти в акк, сообщения будут слева ( должны быть справа ), при перезагрузке страницы баг пропадает_

### В чем было дело:
В useEffect нужно было следить помимо `activeChatID `за сменой `currentUser`